### PR TITLE
Feat/reusable modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 Node.js 16.x
 
-# install dependencies
+_install dependencies_
 ```bash
 npm install
 ```
 
-# run the development server:
+_run the development server_
 ```bash
 npm run dev
 # or

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+Node.js 16.x
 
+# install dependencies
+```bash
+npm install
+```
+
+# run the development server:
 ```bash
 npm run dev
 # or
@@ -21,6 +27,32 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+
+## How to use the Modal component
+
+Portal was needed to make sure Modal component renders properly considering position absolute as the whole father-component (match4action_web\src\app\layout.tsx).
+
+```js
+import { useState } from "react";
+import Modal from "relative-path/Modal";
+import Portal from "relative-path/HOC/modal-portal";
+
+const [openModal, setIsOpen] = useState(false);
+
+// inside JSX
+{openModal ?
+  <Portal>
+    <Modal
+      modalTitle="Title"
+      firstButtonTitle="Yes"
+      lastButtonTitle="Cancel"
+      firstButtonFunction={() => { handleLogout() }}
+      lastButtonFunction={() => { setIsOpen(!openModal) }}
+  />
+  </Portal> :
+  <></>
+}
+```
 
 ## Learn More
 

--- a/src/HOC/modal-portal.tsx
+++ b/src/HOC/modal-portal.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+const Portal = ({ children }: any) => {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+
+    return () => setMounted(false)
+  }, [])
+
+  return mounted
+    ? createPortal(children,
+      document.querySelector("#modal-portal") as HTMLElement)
+    : null
+}
+
+export default Portal

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <LayoutContext accessToken={accessToken}>{children}</LayoutContext>
+        <LayoutContext accessToken={accessToken}>
+          {children}
+          <div id="modal-portal"></div>
+        </LayoutContext>
       </body>
     </html>
   );

--- a/src/modules/components/Drawer/index.tsx
+++ b/src/modules/components/Drawer/index.tsx
@@ -10,8 +10,10 @@ import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import NextLink from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Dispatch, SetStateAction, useCallback, useContext, useMemo } from 'react';
+import { Dispatch, SetStateAction, useCallback, useContext, useMemo, useState } from 'react';
 import { Item } from './Item';
+import Modal from "../Modal";
+import Portal from "@/HOC/modal-portal";
 
 export type DrawerItem = {
   name: string;
@@ -39,6 +41,7 @@ export const TemporaryDrawer = ({ open, toggleDrawer }: TemporaryDrawerProps) =>
   const router = useRouter();
   const { isLogged } = useContext(UserContext) ?? {};
   const { setUser } = useContext(UserContext) ?? {};
+  const [openModal, setIsOpen] = useState(false);
 
   const handleLogout = useCallback(async () => {
     const response = await logout();
@@ -49,6 +52,10 @@ export const TemporaryDrawer = ({ open, toggleDrawer }: TemporaryDrawerProps) =>
       toggleDrawer(false);
       router.push('/');
     }
+  }, []);
+
+  const setOpenModal = useCallback(async () => {
+    setIsOpen(!openModal)
   }, []);
 
   const authenticatedUserMenuList: DrawerItem[] = useMemo(
@@ -118,7 +125,7 @@ export const TemporaryDrawer = ({ open, toggleDrawer }: TemporaryDrawerProps) =>
             }}
           />
         ),
-        action: handleLogout,
+        action: setOpenModal,
       },
     ],
     []
@@ -156,6 +163,19 @@ export const TemporaryDrawer = ({ open, toggleDrawer }: TemporaryDrawerProps) =>
           </Box>
         ))}
       </Box>
+
+      {openModal ?
+        <Portal>
+          <Modal
+            modalTitle="Are you sure you want to log out?"
+            firstButtonTitle="Yes"
+            lastButtonTitle="Cancel"
+            firstButtonFunction={() => { handleLogout() }}
+            lastButtonFunction={() => { setIsOpen(!openModal) }}
+          />
+        </Portal> :
+        <></>
+      }
     </Drawer>
   );
 };

--- a/src/modules/components/Header/HeaderButton/index.tsx
+++ b/src/modules/components/Header/HeaderButton/index.tsx
@@ -5,6 +5,7 @@ import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import Modal from "../../Modal";
+import Portal from "@/HOC/modal-portal";
 
 export interface HeaderButtonInterface {
   accessToken?: string;
@@ -92,8 +93,8 @@ export const HeaderButton = ({ accessToken }: HeaderButtonInterface) => {
               [theme.breakpoints.up(1130)]: {
                 background: "#FFD15C",
                 color: "#000000",
-                fontWeight: 400,
-                fontSize: "1rem",
+                fontWeight: 600,
+                fontSize: "0.7rem",
                 ":focus": {
                   background: "#FFD15C",
                 },
@@ -111,13 +112,15 @@ export const HeaderButton = ({ accessToken }: HeaderButtonInterface) => {
           </Button>
 
           {openModal ?
-            <Modal
-              modalTitle="Are you sure you want to log out?"
-              firstButtonTitle="Yes"
-              lastButtonTitle="Cancel"
-              firstButtonFunction={() => { handleLogout() }}
-              lastButtonFunction={() => { setIsOpen(!openModal) }}
-            /> :
+            <Portal>
+              <Modal
+                modalTitle="Are you sure you want to log out?"
+                firstButtonTitle="Yes"
+                lastButtonTitle="Cancel"
+                firstButtonFunction={() => { handleLogout() }}
+                lastButtonFunction={() => { setIsOpen(!openModal) }}
+              />
+            </Portal> :
             <></>
           }
         </>

--- a/src/modules/components/Header/HeaderButton/index.tsx
+++ b/src/modules/components/Header/HeaderButton/index.tsx
@@ -3,6 +3,8 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import NextLink from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
+import Modal from "../../Modal";
 
 export interface HeaderButtonInterface {
   accessToken?: string;
@@ -15,6 +17,8 @@ export const HeaderButton = ({ accessToken }: HeaderButtonInterface) => {
     "login",
     "register",
   ].includes(pathname as string);
+
+  const [openModal, setIsOpen] = useState(false);
 
   const handleLogout = async () => {
     await logout();
@@ -65,45 +69,58 @@ export const HeaderButton = ({ accessToken }: HeaderButtonInterface) => {
           </Button>
         </NextLink>
       ) : accessToken ? (
-        <Button
-          onClick={handleLogout}
-          sx={(theme) => ({
-            [theme.breakpoints.down(1130)]: {
-              background: "#FFD15C",
-              color: "#000000",
-              fontWeight: 400,
-              fontSize: "0.75rem",
-              ":focus": {
+        <>
+          <Button
+            onClick={() => setIsOpen(!openModal)}
+            sx={(theme) => ({
+              [theme.breakpoints.down(1130)]: {
                 background: "#FFD15C",
+                color: "#000000",
+                fontWeight: 400,
+                fontSize: "0.75rem",
+                ":focus": {
+                  background: "#FFD15C",
+                },
+                ":active": {
+                  background: "#FFD15C",
+                },
+                ":hover": {
+                  background: "#FFD15C",
+                },
+                textTransform: "capitalize",
               },
-              ":active": {
+              [theme.breakpoints.up(1130)]: {
                 background: "#FFD15C",
+                color: "#000000",
+                fontWeight: 400,
+                fontSize: "1rem",
+                ":focus": {
+                  background: "#FFD15C",
+                },
+                ":active": {
+                  background: "#FFD15C",
+                },
+                ":hover": {
+                  background: "#FFD15C",
+                },
+                textTransform: "capitalize",
               },
-              ":hover": {
-                background: "#FFD15C",
-              },
-              textTransform: "capitalize",
-            },
-            [theme.breakpoints.up(1130)]: {
-              background: "#FFD15C",
-              color: "#000000",
-              fontWeight: 400,
-              fontSize: "1rem",
-              ":focus": {
-                background: "#FFD15C",
-              },
-              ":active": {
-                background: "#FFD15C",
-              },
-              ":hover": {
-                background: "#FFD15C",
-              },
-              textTransform: "capitalize",
-            },
-          })}
-        >
-          Log out
-        </Button>
+            })}
+          >
+            Log out
+          </Button>
+
+          {openModal ?
+            <Modal
+              modalTitle="Are you sure you want to log out?"
+              firstButtonTitle="Yes"
+              lastButtonTitle="Cancel"
+              firstButtonFunction={() => { handleLogout() }}
+              lastButtonFunction={() => { setIsOpen(!openModal) }}
+            /> :
+            <></>
+          }
+        </>
       ) : (
         <Box width="4rem" />
       )}

--- a/src/modules/components/Modal/index.tsx
+++ b/src/modules/components/Modal/index.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import CloseIcon from '@mui/icons-material/Close';
+import { lato } from "@/modules/styles/fonts";
 
 export interface ModalInterface {
   modalTitle: string;
@@ -18,7 +19,8 @@ export default function Modal({
   lastButtonFunction
 }: ModalInterface) {
   return (
-    <>
+    <Typography
+      className={lato.className}>
       <Box style={{
         background: "rgba(0, 0, 0, 0.6)",
         backdropFilter: "blur(5px)",
@@ -36,19 +38,34 @@ export default function Modal({
           background: "#ffffff",
           width: "70%",
           maxWidth: "20.4rem",
-          height: "15.9rem",
-        }}>
+          height: "18rem"
+        }}
+          sx={(theme) => ({
+            [theme.breakpoints.down(1130)]: {
+              marginTop: "-290%"
+            },
+            [theme.breakpoints.up(1130)]: {
+              marginTop: "-140%"
+            },
+          })}>
 
-          <Button>
+          <Button
+            onClick={() => { lastButtonFunction() }}
+            style={{
+              background: "transparent",
+              width: "20%",
+              marginLeft: "17.2rem"
+            }}
+          >
             <CloseIcon style={{
               color: "#000000",
-              marginTop: "0.2rem",
-              marginLeft: "18rem"
+              width: "28px",
+              height: "28px"
             }} />
           </Button>
 
           <Box style={{
-            padding: "24px",
+            padding: "20px",
             display: "flex",
             flexDirection: "column",
             gap: "1rem",
@@ -59,7 +76,11 @@ export default function Modal({
 
             <h1
               style={{
+                maxWidth: "283px",
+                maxHeight: "20px",
                 lineHeight: "1.18rem",
+                marginBottom: "3.2rem",
+                fontSize: "1.1rem",
                 fontWeight: 400,
                 color: "rgba(44, 50, 53, 1)"
               }}
@@ -72,12 +93,13 @@ export default function Modal({
               style={{
                 width: "9.75rem",
                 height: "2.43rem",
+                marginBottom: "0.7rem",
                 boxShadow: "0px 10px 20px 0px rgba(0, 0, 0, 0.15)"
               }}
               sx={(theme) => ({
                 [theme.breakpoints.down(1130)]: {
                   background: "#FFD15C",
-                  color: "#000000",
+                  color: "rgba(44, 50, 53, 0.9)",
                   fontWeight: 600,
                   fontSize: "0.75rem",
                   ":focus": {
@@ -93,9 +115,9 @@ export default function Modal({
                 },
                 [theme.breakpoints.up(1130)]: {
                   background: "#FFD15C",
-                  color: "#000000",
+                  color: "rgba(44, 50, 53, 0.9)",
                   fontWeight: 600,
-                  fontSize: "1.1rem",
+                  fontSize: "1rem",
                   ":focus": {
                     background: "#FFD15C",
                   },
@@ -118,7 +140,7 @@ export default function Modal({
                 background: "transparent",
                 border: "none",
                 width: "3rem",
-                height: "1.18rem",
+                lineHeight: "1.18rem",
                 fontWeight: 600,
                 color: "linear-gradient(136.74deg, #B577E1 6.64%, #554BBD 69.76%)",
                 textTransform: "capitalize"
@@ -129,7 +151,7 @@ export default function Modal({
 
                 },
                 [theme.breakpoints.up(1130)]: {
-                  fontSize: "1.1rem"
+                  fontSize: "1rem"
                 },
               })}
             >
@@ -138,6 +160,6 @@ export default function Modal({
           </Box>
         </Box>
       </Box>
-    </>
+    </Typography>
   );
 }

--- a/src/modules/components/Modal/index.tsx
+++ b/src/modules/components/Modal/index.tsx
@@ -1,0 +1,143 @@
+import { Button } from "@mui/material";
+import Box from "@mui/material/Box";
+import CloseIcon from '@mui/icons-material/Close';
+
+export interface ModalInterface {
+  modalTitle: string;
+  firstButtonTitle: string;
+  lastButtonTitle: string;
+  firstButtonFunction: Function;
+  lastButtonFunction: Function;
+}
+
+export default function Modal({
+  modalTitle,
+  firstButtonTitle,
+  lastButtonTitle,
+  firstButtonFunction,
+  lastButtonFunction
+}: ModalInterface) {
+  return (
+    <>
+      <Box style={{
+        background: "rgba(0, 0, 0, 0.6)",
+        backdropFilter: "blur(5px)",
+        position: "absolute",
+        width: "100%",
+        height: "100%",
+        left: 0,
+        top: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+      }}>
+
+        <Box style={{
+          background: "#ffffff",
+          width: "70%",
+          maxWidth: "20.4rem",
+          height: "15.9rem",
+        }}>
+
+          <Button>
+            <CloseIcon style={{
+              color: "#000000",
+              marginTop: "0.2rem",
+              marginLeft: "18rem"
+            }} />
+          </Button>
+
+          <Box style={{
+            padding: "24px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "1rem",
+            alignItems: "center",
+            justifyContent: "center"
+          }}
+          >
+
+            <h1
+              style={{
+                lineHeight: "1.18rem",
+                fontWeight: 400,
+                color: "rgba(44, 50, 53, 1)"
+              }}
+            >
+              {modalTitle}
+            </h1>
+
+            <Button
+              onClick={() => { firstButtonFunction() }}
+              style={{
+                width: "9.75rem",
+                height: "2.43rem",
+                boxShadow: "0px 10px 20px 0px rgba(0, 0, 0, 0.15)"
+              }}
+              sx={(theme) => ({
+                [theme.breakpoints.down(1130)]: {
+                  background: "#FFD15C",
+                  color: "#000000",
+                  fontWeight: 600,
+                  fontSize: "0.75rem",
+                  ":focus": {
+                    background: "#FFD15C",
+                  },
+                  ":active": {
+                    background: "#FFD15C",
+                  },
+                  ":hover": {
+                    background: "#FFD15C",
+                  },
+                  textTransform: "capitalize",
+                },
+                [theme.breakpoints.up(1130)]: {
+                  background: "#FFD15C",
+                  color: "#000000",
+                  fontWeight: 600,
+                  fontSize: "1.1rem",
+                  ":focus": {
+                    background: "#FFD15C",
+                  },
+                  ":active": {
+                    background: "#FFD15C",
+                  },
+                  ":hover": {
+                    background: "#FFD15C",
+                  },
+                  textTransform: "capitalize",
+                },
+              })}
+            >
+              {firstButtonTitle}
+            </Button>
+
+            <Button
+              onClick={() => { lastButtonFunction() }}
+              style={{
+                background: "transparent",
+                border: "none",
+                width: "3rem",
+                height: "1.18rem",
+                fontWeight: 600,
+                color: "linear-gradient(136.74deg, #B577E1 6.64%, #554BBD 69.76%)",
+                textTransform: "capitalize"
+              }}
+              sx={(theme) => ({
+                [theme.breakpoints.down(1130)]: {
+                  fontSize: "0.75rem"
+
+                },
+                [theme.breakpoints.up(1130)]: {
+                  fontSize: "1.1rem"
+                },
+              })}
+            >
+              {lastButtonTitle}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/src/modules/styles/fonts.ts
+++ b/src/modules/styles/fonts.ts
@@ -1,4 +1,4 @@
-import { Lato, Source_Serif_Pro } from 'next/font/google';
+import { Lato, Source_Serif_4 } from 'next/font/google';
 
 export const lato = Lato({
   weight: ['400', '700', '100', '300', '900'],
@@ -6,7 +6,7 @@ export const lato = Lato({
   fallback: ['Helvetica', 'Arial', 'sans-serif'],
 });
 
-export const sourceSerifPro = Source_Serif_Pro({
+export const sourceSerifPro = Source_Serif_4({
   weight: ['700', '200', '300', '400', '600', '900'],
   subsets: ['latin'],
   fallback: ['Helvetica', 'Arial', 'sans-serif'],


### PR DESCRIPTION
## Description

Implementation of a Reusable Modal Component for Confirmation Modals (Logout and Remove Initiative from Wishlist and wherever more it's needed) for Match4Action Website

## Expected Behavior

Open a modal wherever is needed to (implementation steps were included on README file)

## Screenshots

Desktop:
![image](https://github.com/match4actiondevelopment/match4action_web/assets/91279365/f5a94ccd-2799-49c3-83e7-b6593c36275a)

Mobile:
![Modal-Responsive](https://github.com/match4actiondevelopment/match4action_web/assets/91279365/e2f70e71-5232-4132-87ee-fc57238898d4)